### PR TITLE
Cleanup before throwing RuntimeError

### DIFF
--- a/imagequant/__init__.py
+++ b/imagequant/__init__.py
@@ -125,6 +125,9 @@ def quantize_raw_rgba_bytes(
     liq_result_p = ffi.new("liq_result**")
     code = lib.liq_image_quantize(liq_image, liq_attr, liq_result_p)
     if code != lib.LIQ_OK:
+        lib.liq_result_destroy(liq_result_p[0])
+        lib.liq_image_destroy(liq_image)
+        lib.liq_attr_destroy(liq_attr)
         raise RuntimeError(_get_error_msg(code))
     lib.liq_set_dithering_level(liq_result_p[0], dithering_level)
 


### PR DESCRIPTION
Currently, `liq_result_p`, `liq_image`, `liq_attr` are not cleaned if RuntimeError occurs.

This can potentially cause memory leak, such as in the following example:

```python
import imagequant
from PIL import Image

def smallest_quant(image: Image) -> Image:
    image_quant = None
    for i in range(11, 101, 5):
        try:
            image_quant = imagequant.quantize_pil_image(  # type: ignore
                image,
                dithering_level=1.0,
                max_colors=256,
                min_quality=0,
                max_quality=i,
            )
            return image_quant
        except RuntimeError:
            pass

    return image
```

This PR cleans up `liq_result_p`, `liq_image`, `liq_attr` before throwing RuntimeError.